### PR TITLE
feat(Title): 칭호 구매 및 장착

### DIFF
--- a/src/main/java/org/example/remedy/application/title/TitleServiceImpl.java
+++ b/src/main/java/org/example/remedy/application/title/TitleServiceImpl.java
@@ -1,0 +1,198 @@
+package org.example.remedy.application.title;
+
+import lombok.RequiredArgsConstructor;
+import org.example.remedy.application.currency.port.in.CurrencyService;
+import org.example.remedy.application.title.dto.response.TitleListResponse;
+import org.example.remedy.application.title.dto.response.TitleResponse;
+import org.example.remedy.application.title.dto.response.UserTitleListResponse;
+import org.example.remedy.application.title.dto.response.UserTitleResponse;
+import org.example.remedy.application.title.exception.TitleAlreadyExistsException;
+import org.example.remedy.application.title.exception.TitleAlreadyOwnedException;
+import org.example.remedy.application.title.exception.TitleNotFoundException;
+import org.example.remedy.application.title.exception.TitleNotOwnedException;
+import org.example.remedy.application.title.port.in.TitleService;
+import org.example.remedy.application.title.port.out.TitlePersistencePort;
+import org.example.remedy.domain.title.Title;
+import org.example.remedy.domain.title.UserTitle;
+import org.example.remedy.domain.user.Role;
+import org.example.remedy.domain.user.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TitleServiceImpl implements TitleService {
+    private final TitlePersistencePort titlePersistencePort;
+    private final CurrencyService currencyService;
+
+    @Override
+    @Transactional
+    public TitleResponse createTitle(String name, String description, Integer price, User admin) {
+        validateAdminRole(admin);
+        
+        if (titlePersistencePort.existsByName(name)) {
+            throw TitleAlreadyExistsException.INSTANCE;
+        }
+        
+        Title title = Title.create(name, description, price, admin.getUserId());
+        Title savedTitle = titlePersistencePort.save(title);
+        
+        return TitleResponse.from(savedTitle);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TitleListResponse getAllTitles() {
+        List<Title> titles = titlePersistencePort.findAll();
+        return TitleListResponse.from(titles);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TitleListResponse getActiveTitles() {
+        List<Title> titles = titlePersistencePort.findByIsActiveTrue();
+        return TitleListResponse.from(titles);
+    }
+
+    @Override
+    @Transactional
+    public TitleResponse updateTitle(Long titleId, String name, String description, Integer price, User admin) {
+        validateAdminRole(admin);
+        
+        Title title = titlePersistencePort.findById(titleId)
+                .orElseThrow(() -> TitleNotFoundException.INSTANCE);
+        
+        if (name != null && !name.equals(title.getName()) && titlePersistencePort.existsByName(name)) {
+            throw TitleAlreadyExistsException.INSTANCE;
+        }
+        
+        title.updateInfo(name, description, price);
+        Title savedTitle = titlePersistencePort.save(title);
+        
+        return TitleResponse.from(savedTitle);
+    }
+
+    @Override
+    @Transactional
+    public void deactivateTitle(Long titleId, User admin) {
+        validateAdminRole(admin);
+        
+        Title title = titlePersistencePort.findById(titleId)
+                .orElseThrow(() -> TitleNotFoundException.INSTANCE);
+        
+        title.deactivate();
+        titlePersistencePort.save(title);
+    }
+
+    @Override
+    @Transactional
+    public void activateTitle(Long titleId, User admin) {
+        validateAdminRole(admin);
+        
+        Title title = titlePersistencePort.findById(titleId)
+                .orElseThrow(() -> TitleNotFoundException.INSTANCE);
+        
+        title.activate();
+        titlePersistencePort.save(title);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserTitleListResponse getUserTitles(User user) {
+        List<UserTitle> userTitles = titlePersistencePort.findByUserId(user.getUserId());
+        
+        List<UserTitleResponse> responses = userTitles.stream()
+                .map(ut -> {
+                    Title title = titlePersistencePort.findById(ut.getTitleId())
+                            .orElseThrow(() -> TitleNotFoundException.INSTANCE);
+                    return UserTitleResponse.from(ut, title);
+                })
+                .toList();
+        
+        return UserTitleListResponse.from(responses);
+    }
+
+    @Override
+    @Transactional
+    public UserTitleResponse purchaseTitle(Long titleId, User user) {
+        Title title = titlePersistencePort.findById(titleId)
+                .orElseThrow(() -> TitleNotFoundException.INSTANCE);
+        
+        if (!title.isActive()) {
+            throw TitleNotFoundException.INSTANCE;
+        }
+        
+        Optional<UserTitle> existingUserTitle = titlePersistencePort.findByUserIdAndTitleId(user.getUserId(), titleId);
+        if (existingUserTitle.isPresent()) {
+            throw TitleAlreadyOwnedException.INSTANCE;
+        }
+        
+        currencyService.spendCurrency(user, title.getPrice());
+        
+        UserTitle userTitle = UserTitle.create(user.getUserId(), titleId);
+        UserTitle savedUserTitle = titlePersistencePort.save(userTitle);
+        
+        return UserTitleResponse.from(savedUserTitle, title);
+    }
+
+    @Override
+    @Transactional
+    public UserTitleResponse equipTitle(Long titleId, User user) {
+        UserTitle userTitle = titlePersistencePort.findByUserIdAndTitleId(user.getUserId(), titleId)
+                .orElseThrow(() -> TitleNotOwnedException.INSTANCE);
+        
+        if (userTitle.isEquipped()) {
+            return UserTitleResponse.from(userTitle, 
+                    titlePersistencePort.findById(titleId)
+                            .orElseThrow(() -> TitleNotFoundException.INSTANCE));
+        }
+        
+        titlePersistencePort.unequipAllTitles(user.getUserId());
+        
+        userTitle.equip();
+        UserTitle savedUserTitle = titlePersistencePort.save(userTitle);
+        
+        Title title = titlePersistencePort.findById(titleId)
+                .orElseThrow(() -> TitleNotFoundException.INSTANCE);
+        
+        return UserTitleResponse.from(savedUserTitle, title);
+    }
+
+    @Override
+    @Transactional
+    public void unequipTitle(Long titleId, User user) {
+        UserTitle userTitle = titlePersistencePort.findByUserIdAndTitleId(user.getUserId(), titleId)
+                .orElseThrow(() -> TitleNotOwnedException.INSTANCE);
+        
+        if (!userTitle.isEquipped()) {
+            return;
+        }
+        
+        userTitle.unequip();
+        titlePersistencePort.save(userTitle);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserTitleResponse getCurrentEquippedTitle(User user) {
+        Optional<UserTitle> equippedTitle = titlePersistencePort.findByUserIdAndIsEquippedTrue(user.getUserId());
+        
+        if (equippedTitle.isEmpty()) {
+            return null;
+        }
+        
+        Title title = titlePersistencePort.findById(equippedTitle.get().getTitleId())
+                .orElseThrow(() -> TitleNotFoundException.INSTANCE);
+        
+        return UserTitleResponse.from(equippedTitle.get(), title);
+    }
+
+    private void validateAdminRole(User user) {
+        if (user.getRole() != Role.ROLE_ADMIN) {
+            throw new IllegalArgumentException("관리자만 칭호를 관리할 수 있습니다.");
+        }
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/dto/response/TitleListResponse.java
+++ b/src/main/java/org/example/remedy/application/title/dto/response/TitleListResponse.java
@@ -1,0 +1,18 @@
+package org.example.remedy.application.title.dto.response;
+
+import org.example.remedy.domain.title.Title;
+
+import java.util.List;
+
+public record TitleListResponse(
+        List<TitleResponse> titles,
+        int totalCount
+) {
+    public static TitleListResponse from(List<Title> titles) {
+        List<TitleResponse> titleResponses = titles.stream()
+                .map(TitleResponse::from)
+                .toList();
+        
+        return new TitleListResponse(titleResponses, titles.size());
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/dto/response/TitleResponse.java
+++ b/src/main/java/org/example/remedy/application/title/dto/response/TitleResponse.java
@@ -1,0 +1,43 @@
+package org.example.remedy.application.title.dto.response;
+
+import org.example.remedy.domain.title.Title;
+
+import java.time.LocalDateTime;
+
+/**
+ * 칭호 정보 응답 DTO
+ * 
+ * 칭호의 기본 정보를 제공합니다.
+ * 
+ * @param titleId 칭호 ID
+ * @param name 칭호 이름
+ * @param description 칭호 설명
+ * @param price 칭호 가격
+ * @param isActive 활성화 상태
+ * @param createdAt 생성 시간
+ */
+public record TitleResponse(
+        Long titleId,
+        String name,
+        String description,
+        Integer price,
+        boolean isActive,
+        LocalDateTime createdAt
+) {
+    /**
+     * Title 엔티티로부터 응답 객체를 생성합니다.
+     * 
+     * @param title 칭호 엔티티
+     * @return 칭호 정보 응답 DTO
+     */
+    public static TitleResponse from(Title title) {
+        return new TitleResponse(
+                title.getTitleId(),
+                title.getName(),
+                title.getDescription(),
+                title.getPrice(),
+                title.isActive(),
+                title.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/dto/response/UserTitleListResponse.java
+++ b/src/main/java/org/example/remedy/application/title/dto/response/UserTitleListResponse.java
@@ -1,0 +1,22 @@
+package org.example.remedy.application.title.dto.response;
+
+import java.util.List;
+
+public record UserTitleListResponse(
+        List<UserTitleResponse> titles,
+        int totalCount,
+        UserTitleResponse equippedTitle
+) {
+    public static UserTitleListResponse from(List<UserTitleResponse> titles) {
+        UserTitleResponse equippedTitle = titles.stream()
+                .filter(UserTitleResponse::isEquipped)
+                .findFirst()
+                .orElse(null);
+        
+        return new UserTitleListResponse(
+                titles,
+                titles.size(),
+                equippedTitle
+        );
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/dto/response/UserTitleResponse.java
+++ b/src/main/java/org/example/remedy/application/title/dto/response/UserTitleResponse.java
@@ -1,0 +1,51 @@
+package org.example.remedy.application.title.dto.response;
+
+import org.example.remedy.domain.title.Title;
+import org.example.remedy.domain.title.UserTitle;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 칭호 정보 응답 DTO
+ * 
+ * 사용자가 보유한 칭호의 상세 정보를 제공합니다.
+ * 
+ * @param userTitleId 사용자 칭호 ID
+ * @param titleId 칭호 ID
+ * @param name 칭호 이름
+ * @param description 칭호 설명
+ * @param price 칭호 가격
+ * @param isEquipped 착용 상태
+ * @param purchasedAt 구매 시간
+ * @param equippedAt 착용 시간
+ */
+public record UserTitleResponse(
+        Long userTitleId,
+        Long titleId,
+        String name,
+        String description,
+        Integer price,
+        boolean isEquipped,
+        LocalDateTime purchasedAt,
+        LocalDateTime equippedAt
+) {
+    /**
+     * UserTitle 및 Title 엔티티로부터 응답 객체를 생성합니다.
+     * 
+     * @param userTitle 사용자 칭호 엔티티
+     * @param title 칭호 엔티티
+     * @return 사용자 칭호 정보 응답 DTO
+     */
+    public static UserTitleResponse from(UserTitle userTitle, Title title) {
+        return new UserTitleResponse(
+                userTitle.getUserTitleId(),
+                title.getTitleId(),
+                title.getName(),
+                title.getDescription(),
+                title.getPrice(),
+                userTitle.isEquipped(),
+                userTitle.getPurchasedAt(),
+                userTitle.getEquippedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/exception/TitleAlreadyExistsException.java
+++ b/src/main/java/org/example/remedy/application/title/exception/TitleAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package org.example.remedy.application.title.exception;
+
+import org.example.remedy.global.error.ErrorCode;
+import org.example.remedy.global.error.exception.AlreadyExistsException;
+
+public class TitleAlreadyExistsException extends AlreadyExistsException {
+    public static final TitleAlreadyExistsException INSTANCE = new TitleAlreadyExistsException();
+
+    private TitleAlreadyExistsException() {
+        super(ErrorCode.TITLE_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/exception/TitleAlreadyOwnedException.java
+++ b/src/main/java/org/example/remedy/application/title/exception/TitleAlreadyOwnedException.java
@@ -1,0 +1,12 @@
+package org.example.remedy.application.title.exception;
+
+import org.example.remedy.global.error.ErrorCode;
+import org.example.remedy.global.error.exception.BusinessBaseException;
+
+public class TitleAlreadyOwnedException extends BusinessBaseException {
+    public static final TitleAlreadyOwnedException INSTANCE = new TitleAlreadyOwnedException();
+
+    private TitleAlreadyOwnedException() {
+        super(ErrorCode.TITLE_ALREADY_OWNED);
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/exception/TitleNotFoundException.java
+++ b/src/main/java/org/example/remedy/application/title/exception/TitleNotFoundException.java
@@ -1,0 +1,12 @@
+package org.example.remedy.application.title.exception;
+
+import org.example.remedy.global.error.ErrorCode;
+import org.example.remedy.global.error.exception.NotFoundException;
+
+public class TitleNotFoundException extends NotFoundException {
+    public static final TitleNotFoundException INSTANCE = new TitleNotFoundException();
+
+    private TitleNotFoundException() {
+        super(ErrorCode.TITLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/exception/TitleNotOwnedException.java
+++ b/src/main/java/org/example/remedy/application/title/exception/TitleNotOwnedException.java
@@ -1,0 +1,12 @@
+package org.example.remedy.application.title.exception;
+
+import org.example.remedy.global.error.ErrorCode;
+import org.example.remedy.global.error.exception.BusinessBaseException;
+
+public class TitleNotOwnedException extends BusinessBaseException {
+    public static final TitleNotOwnedException INSTANCE = new TitleNotOwnedException();
+
+    private TitleNotOwnedException() {
+        super(ErrorCode.TITLE_NOT_OWNED);
+    }
+}

--- a/src/main/java/org/example/remedy/application/title/port/in/TitleService.java
+++ b/src/main/java/org/example/remedy/application/title/port/in/TitleService.java
@@ -1,0 +1,109 @@
+package org.example.remedy.application.title.port.in;
+
+import org.example.remedy.application.title.dto.response.TitleListResponse;
+import org.example.remedy.application.title.dto.response.TitleResponse;
+import org.example.remedy.application.title.dto.response.UserTitleListResponse;
+import org.example.remedy.application.title.dto.response.UserTitleResponse;
+import org.example.remedy.domain.user.User;
+
+/**
+ * 칭호 서비스 인터페이스
+ * 
+ * 칭호 관리, 사용자 칭호 관리 및 칭호 거래 기능을 정의합니다.
+ */
+public interface TitleService {
+    /**
+     * 새로운 칭호 생성
+     * 
+     * @param name 칭호 이름
+     * @param description 칭호 설명
+     * @param price 칭호 가격
+     * @param admin 관리자 정보
+     * @return 생성된 칭호 정보
+     */
+    TitleResponse createTitle(String name, String description, Integer price, User admin);
+    
+    /**
+     * 모든 칭호 목록 조회 (관리자용)
+     * 
+     * @return 전체 칭호 목록 (비활성화된 칭호 포함)
+     */
+    TitleListResponse getAllTitles();
+    
+    /**
+     * 활성 칭호 목록 조회 (사용자용)
+     * 
+     * @return 활성화된 칭호 목록
+     */
+    TitleListResponse getActiveTitles();
+    
+    /**
+     * 칭호 정보 수정
+     * 
+     * @param titleId 수정할 칭호 ID
+     * @param name 새로운 칭호 이름
+     * @param description 새로운 칭호 설명
+     * @param price 새로운 칭호 가격
+     * @param admin 관리자 정보
+     * @return 수정된 칭호 정보
+     */
+    TitleResponse updateTitle(Long titleId, String name, String description, Integer price, User admin);
+    
+    /**
+     * 칭호 비활성화
+     * 
+     * @param titleId 비활성화할 칭호 ID
+     * @param admin 관리자 정보
+     */
+    void deactivateTitle(Long titleId, User admin);
+    
+    /**
+     * 칭호 활성화
+     * 
+     * @param titleId 활성화할 칭호 ID
+     * @param admin 관리자 정보
+     */
+    void activateTitle(Long titleId, User admin);
+    
+    /**
+     * 사용자 보유 칭호 목록 조회
+     * 
+     * @param user 사용자 정보
+     * @return 사용자가 보유한 칭호 목록
+     */
+    UserTitleListResponse getUserTitles(User user);
+    
+    /**
+     * 칭호 구매
+     * 
+     * @param titleId 구매할 칭호 ID
+     * @param user 구매자 정보
+     * @return 구매된 칭호 정보
+     */
+    UserTitleResponse purchaseTitle(Long titleId, User user);
+    
+    /**
+     * 칭호 착용
+     * 
+     * @param titleId 착용할 칭호 ID
+     * @param user 사용자 정보
+     * @return 착용된 칭호 정보
+     */
+    UserTitleResponse equipTitle(Long titleId, User user);
+    
+    /**
+     * 칭호 해제
+     * 
+     * @param titleId 해제할 칭호 ID
+     * @param user 사용자 정보
+     */
+    void unequipTitle(Long titleId, User user);
+    
+    /**
+     * 현재 착용 중인 칭호 조회
+     * 
+     * @param user 사용자 정보
+     * @return 현재 착용 중인 칭호 정보
+     */
+    UserTitleResponse getCurrentEquippedTitle(User user);
+}

--- a/src/main/java/org/example/remedy/application/title/port/out/TitlePersistencePort.java
+++ b/src/main/java/org/example/remedy/application/title/port/out/TitlePersistencePort.java
@@ -1,0 +1,29 @@
+package org.example.remedy.application.title.port.out;
+
+import org.example.remedy.domain.title.Title;
+import org.example.remedy.domain.title.UserTitle;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TitlePersistencePort {
+    Title save(Title title);
+    
+    Optional<Title> findById(Long titleId);
+    
+    List<Title> findAll();
+    
+    List<Title> findByIsActiveTrue();
+    
+    boolean existsByName(String name);
+    
+    UserTitle save(UserTitle userTitle);
+    
+    Optional<UserTitle> findByUserIdAndTitleId(Long userId, Long titleId);
+    
+    List<UserTitle> findByUserId(Long userId);
+    
+    Optional<UserTitle> findByUserIdAndIsEquippedTrue(Long userId);
+    
+    void unequipAllTitles(Long userId);
+}

--- a/src/main/java/org/example/remedy/domain/title/Title.java
+++ b/src/main/java/org/example/remedy/domain/title/Title.java
@@ -1,0 +1,94 @@
+package org.example.remedy.domain.title;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 칭호 엔티티
+ * 사용자가 구매하고 장착할 수 있는 칭호 정보를 관리
+ */
+@Getter
+@NoArgsConstructor
+@Table(name = "titles")
+@Entity
+public class Title {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long titleId; // 칭호 ID
+
+    @Column(nullable = false, length = 50, unique = true)
+    private String name; // 칭호 이름 (고유)
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description; // 칭호 설명
+
+    @Column(nullable = false)
+    private Integer price; // 칭호 가격 (재화로 구매)
+
+    @Column(nullable = false)
+    private boolean isActive = true; // 활성화 여부
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt; // 생성 시간
+
+    @Column(nullable = false)
+    private Long createdBy; // 생성자 (관리자) ID
+
+    private Title(String name, String description, Integer price, Long createdBy) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.createdBy = createdBy;
+        this.createdAt = LocalDateTime.now();
+        this.isActive = true;
+    }
+
+    /**
+     * 칭호 생성
+     * @param name 칭호 이름
+     * @param description 칭호 설명
+     * @param price 칭호 가격
+     * @param createdBy 생성자 (관리자) ID
+     * @return 새로운 Title 인스턴스
+     */
+    public static Title create(String name, String description, Integer price, Long createdBy) {
+        return new Title(name, description, price, createdBy);
+    }
+
+    /**
+     * 칭호 비활성화
+     * 비활성화된 칭호는 구매할 수 없음
+     */
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    /**
+     * 칭호 활성화
+     * 활성화된 칭호만 구매 가능
+     */
+    public void activate() {
+        this.isActive = true;
+    }
+
+    /**
+     * 칭호 정보 업데이트
+     * @param name 수정할 칭호 이름 (null이면 변경 안함)
+     * @param description 수정할 칭호 설명 (null이면 변경 안함)
+     * @param price 수정할 칭호 가격 (null이면 변경 안함)
+     */
+    public void updateInfo(String name, String description, Integer price) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (description != null && !description.isBlank()) {
+            this.description = description;
+        }
+        if (price != null && price >= 0) {
+            this.price = price;
+        }
+    }
+}

--- a/src/main/java/org/example/remedy/domain/title/UserTitle.java
+++ b/src/main/java/org/example/remedy/domain/title/UserTitle.java
@@ -1,0 +1,70 @@
+package org.example.remedy.domain.title;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자가 보유한 칭호 엔티티
+ * 사용자가 구매한 칭호와 장착 상태를 관리
+ */
+@Getter
+@NoArgsConstructor
+@Table(name = "user_titles",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "title_id"}))
+@Entity
+public class UserTitle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userTitleId; // 사용자 칭호 ID
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId; // 사용자 ID
+
+    @Column(name = "title_id", nullable = false)
+    private Long titleId; // 칭호 ID
+
+    @Column(nullable = false)
+    private boolean isEquipped = false; // 장착 여부
+
+    @Column(nullable = false)
+    private LocalDateTime purchasedAt; // 구매 시간
+
+    private LocalDateTime equippedAt; // 장착 시간
+
+    private UserTitle(Long userId, Long titleId) {
+        this.userId = userId;
+        this.titleId = titleId;
+        this.isEquipped = false;
+        this.purchasedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 사용자 칭호 생성 (구매 시)
+     * @param userId 사용자 ID
+     * @param titleId 칭호 ID
+     * @return 새로운 UserTitle 인스턴스
+     */
+    public static UserTitle create(Long userId, Long titleId) {
+        return new UserTitle(userId, titleId);
+    }
+
+    /**
+     * 칭호 장착
+     * 한 번에 하나의 칭호만 장착 가능하므로, 다른 칭호는 해제 후 장착해야 함
+     */
+    public void equip() {
+        this.isEquipped = true;
+        this.equippedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 칭호 장착 해제
+     */
+    public void unequip() {
+        this.isEquipped = false;
+        this.equippedAt = null;
+    }
+}

--- a/src/main/java/org/example/remedy/infrastructure/persistence/title/JpaTitleAdapter.java
+++ b/src/main/java/org/example/remedy/infrastructure/persistence/title/JpaTitleAdapter.java
@@ -1,0 +1,67 @@
+package org.example.remedy.infrastructure.persistence.title;
+
+import lombok.RequiredArgsConstructor;
+import org.example.remedy.application.title.port.out.TitlePersistencePort;
+import org.example.remedy.domain.title.Title;
+import org.example.remedy.domain.title.UserTitle;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class JpaTitleAdapter implements TitlePersistencePort {
+    private final TitleRepository titleRepository;
+    private final UserTitleRepository userTitleRepository;
+
+    @Override
+    public Title save(Title title) {
+        return titleRepository.save(title);
+    }
+
+    @Override
+    public Optional<Title> findById(Long titleId) {
+        return titleRepository.findById(titleId);
+    }
+
+    @Override
+    public List<Title> findAll() {
+        return titleRepository.findAll();
+    }
+
+    @Override
+    public List<Title> findByIsActiveTrue() {
+        return titleRepository.findByIsActiveTrue();
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return titleRepository.existsByName(name);
+    }
+
+    @Override
+    public UserTitle save(UserTitle userTitle) {
+        return userTitleRepository.save(userTitle);
+    }
+
+    @Override
+    public Optional<UserTitle> findByUserIdAndTitleId(Long userId, Long titleId) {
+        return userTitleRepository.findByUserIdAndTitleId(userId, titleId);
+    }
+
+    @Override
+    public List<UserTitle> findByUserId(Long userId) {
+        return userTitleRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Optional<UserTitle> findByUserIdAndIsEquippedTrue(Long userId) {
+        return userTitleRepository.findByUserIdAndIsEquippedTrue(userId);
+    }
+
+    @Override
+    public void unequipAllTitles(Long userId) {
+        userTitleRepository.unequipAllTitles(userId);
+    }
+}

--- a/src/main/java/org/example/remedy/infrastructure/persistence/title/TitleRepository.java
+++ b/src/main/java/org/example/remedy/infrastructure/persistence/title/TitleRepository.java
@@ -1,0 +1,11 @@
+package org.example.remedy.infrastructure.persistence.title;
+
+import org.example.remedy.domain.title.Title;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TitleRepository extends JpaRepository<Title, Long> {
+    List<Title> findByIsActiveTrue();
+    boolean existsByName(String name);
+}

--- a/src/main/java/org/example/remedy/infrastructure/persistence/title/UserTitleRepository.java
+++ b/src/main/java/org/example/remedy/infrastructure/persistence/title/UserTitleRepository.java
@@ -1,0 +1,20 @@
+package org.example.remedy.infrastructure.persistence.title;
+
+import org.example.remedy.domain.title.UserTitle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserTitleRepository extends JpaRepository<UserTitle, Long> {
+    Optional<UserTitle> findByUserIdAndTitleId(Long userId, Long titleId);
+    List<UserTitle> findByUserId(Long userId);
+    Optional<UserTitle> findByUserIdAndIsEquippedTrue(Long userId);
+    
+    @Modifying
+    @Query("UPDATE UserTitle ut SET ut.isEquipped = false WHERE ut.userId = :userId AND ut.isEquipped = true")
+    void unequipAllTitles(@Param("userId") Long userId);
+}

--- a/src/main/java/org/example/remedy/presentation/title/TitleController.java
+++ b/src/main/java/org/example/remedy/presentation/title/TitleController.java
@@ -1,0 +1,120 @@
+package org.example.remedy.presentation.title;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.remedy.application.title.dto.response.TitleListResponse;
+import org.example.remedy.application.title.dto.response.TitleResponse;
+import org.example.remedy.application.title.dto.response.UserTitleListResponse;
+import org.example.remedy.application.title.dto.response.UserTitleResponse;
+import org.example.remedy.application.title.port.in.TitleService;
+import org.example.remedy.global.security.auth.AuthDetails;
+import org.example.remedy.presentation.title.dto.request.TitleCreateRequest;
+import org.example.remedy.presentation.title.dto.request.TitleUpdateRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/titles")
+public class TitleController {
+    private final TitleService titleService;
+
+    @PostMapping
+    public ResponseEntity<TitleResponse> createTitle(
+            @RequestBody @Valid TitleCreateRequest request,
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        TitleResponse response = titleService.createTitle(
+                request.name(),
+                request.description(),
+                request.price(),
+                authDetails.getUser()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<TitleListResponse> getAllTitles() {
+        TitleListResponse response = titleService.getAllTitles();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<TitleListResponse> getActiveTitles() {
+        TitleListResponse response = titleService.getActiveTitles();
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{titleId}")
+    public ResponseEntity<TitleResponse> updateTitle(
+            @PathVariable Long titleId,
+            @RequestBody @Valid TitleUpdateRequest request,
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        TitleResponse response = titleService.updateTitle(
+                titleId,
+                request.name(),
+                request.description(),
+                request.price(),
+                authDetails.getUser()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{titleId}/deactivate")
+    public ResponseEntity<Void> deactivateTitle(
+            @PathVariable Long titleId,
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        titleService.deactivateTitle(titleId, authDetails.getUser());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{titleId}/activate")
+    public ResponseEntity<Void> activateTitle(
+            @PathVariable Long titleId,
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        titleService.activateTitle(titleId, authDetails.getUser());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<UserTitleListResponse> getUserTitles(
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        UserTitleListResponse response = titleService.getUserTitles(authDetails.getUser());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{titleId}/purchase")
+    public ResponseEntity<UserTitleResponse> purchaseTitle(
+            @PathVariable Long titleId,
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        UserTitleResponse response = titleService.purchaseTitle(titleId, authDetails.getUser());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{titleId}/equip")
+    public ResponseEntity<UserTitleResponse> equipTitle(
+            @PathVariable Long titleId,
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        UserTitleResponse response = titleService.equipTitle(titleId, authDetails.getUser());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{titleId}/unequip")
+    public ResponseEntity<Void> unequipTitle(
+            @PathVariable Long titleId,
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        titleService.unequipTitle(titleId, authDetails.getUser());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/equipped")
+    public ResponseEntity<UserTitleResponse> getCurrentEquippedTitle(
+            @AuthenticationPrincipal AuthDetails authDetails) {
+        UserTitleResponse response = titleService.getCurrentEquippedTitle(authDetails.getUser());
+        if (response == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/example/remedy/presentation/title/dto/request/TitleCreateRequest.java
+++ b/src/main/java/org/example/remedy/presentation/title/dto/request/TitleCreateRequest.java
@@ -1,0 +1,28 @@
+package org.example.remedy.presentation.title.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 칭호 생성 요청 DTO
+ * 
+ * 관리자가 새로운 칭호를 생성할 때 사용하는 요청 객체입니다.
+ * 
+ * @param name 칭호 이름 (필수, 최대 50자)
+ * @param description 칭호 설명 (필수)
+ * @param price 칭호 가격 (필수, 0 이상)
+ */
+public record TitleCreateRequest(
+        @NotBlank(message = "칭호 이름은 필수입니다.")
+        @Size(max = 50, message = "칭호 이름은 최대 50자까지 입력 가능합니다.")
+        String name,
+
+        @NotBlank(message = "칭호 설명은 필수입니다.")
+        String description,
+
+        @NotNull(message = "가격은 필수입니다.")
+        @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+        Integer price
+) {}

--- a/src/main/java/org/example/remedy/presentation/title/dto/request/TitleUpdateRequest.java
+++ b/src/main/java/org/example/remedy/presentation/title/dto/request/TitleUpdateRequest.java
@@ -1,0 +1,14 @@
+package org.example.remedy.presentation.title.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record TitleUpdateRequest(
+        @Size(max = 50, message = "칭호 이름은 최대 50자까지 입력 가능합니다.")
+        String name,
+
+        String description,
+
+        @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+        Integer price
+) {}


### PR DESCRIPTION
이름, 설명, 가격을 가진 Title 도메인 엔티티 추가

사용자가 보유한 칭호와 장착 상태를 관리하는 UserTitle 엔티티 추가

구매, 장착, 해제를 지원하는 TitleService 구현

칭호 관련 DTO 추가 (TitleResponse, UserTitleResponse, TitleListResponse)

칭호 요청 DTO 추가 (TitleCreateRequest, TitleUpdateRequest)

칭호 관련 예외 추가 (TitleNotFoundException, TitleAlreadyOwnedException 등)

영속성 계층을 위한 JpaTitleAdapter 구현

칭호 관리를 위한 TitleController REST 엔드포인트 추가

칭호 활성/비활성화 및 장착된 칭호 추적 기능 지원

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 칭호 시스템 추가: 칭호 목록 조회(전체/활성), 내 칭호 조회, 구매, 장착/해제, 현재 장착 칭호 조회 지원
  * 관리자 기능: 칭호 생성, 수정, 활성화/비활성화
* 개선
  * 요청 유효성 검증 강화: 이름 길이, 필수값, 가격 최소값(0 이상) 검증
* 오류 처리
  * 존재하지 않음, 중복, 이미 소유/미소유 등 시나리오에 대한 표준화된 에러 응답 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->